### PR TITLE
chore: add CI/CD, changelog, and npm publishing metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run build
+
+      - run: npm run test:coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run build
+
+      - run: npm test
+
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-02-11
+
+### Added
+
+- **CoinbaseAgentTool** node: AI tool node with 7 LangChain tools for n8n AI Agent
+  - `get_wallet_details` — get or create EVM account
+  - `native_transfer` — send ETH/native tokens
+  - `erc20_transfer` — send ERC-20 tokens
+  - `get_balance` — check token balances
+  - `swap_tokens` — execute token swaps
+  - `get_swap_price` — quote swap prices
+  - `request_faucet` — request testnet tokens
+- **CoinbaseCdp** node: action node with 7 resources, 16 operations
+  - Account (getOrCreate, listBalances, requestFaucet)
+  - Solana Account (getOrCreate, requestFaucet)
+  - Smart Account (getOrCreate)
+  - Transfer (sendNative, sendErc20)
+  - Swap (execute, quote)
+  - Policy (list, get, create, update, delete)
+  - Balance (listTokens)
+  - `usableAsTool: true` for AI Agent compatibility
+- **CoinbaseTrigger** node: polling trigger for balance change monitoring
+- **CoinbaseCdpApi** credential: API Key ID, API Secret, Wallet Secret
+- Support for 12 networks (10 EVM + 2 Solana)
+- 7 example workflows
+- 116 unit tests with 100% code coverage
+- E2E test runner against live n8n
+
+[0.1.0]: https://github.com/pvdyck/n8n-nodes-coinbase-cdp/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -16,9 +16,16 @@
   "author": {
     "name": "pvdyck"
   },
+  "homepage": "https://github.com/pvdyck/n8n-nodes-coinbase-cdp#readme",
+  "bugs": {
+    "url": "https://github.com/pvdyck/n8n-nodes-coinbase-cdp/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/pvdyck/n8n-nodes-coinbase-cdp"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Add GitHub Actions **CI workflow** (lint, build, test on every PR and push to main)
- Add GitHub Actions **release workflow** (npm publish with provenance on version tag `v*`)
- Add **CHANGELOG.md** for v0.1.0 following Keep a Changelog format
- Add missing **package.json** fields: `homepage`, `bugs`, `engines` (Node >= 22)

## Setup needed after merge

1. Add `NPM_TOKEN` secret to GitHub repo (Settings > Secrets > Actions)
2. First npm publish: `npm login && npm publish --access public`
3. Then tag: `git tag v0.1.0 && git push origin v0.1.0`

Subsequent releases: push a `v*` tag and GitHub Actions handles the rest.